### PR TITLE
feat: useExperimentAsync refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,42 @@ const AddToCartButtonExperiment = () => {
     enableForceExperiment: true
   };
  
-  const { variant: { name } } = useExperiment(experimentConfig)
+  const variant = useExperiment(experimentConfig)
 
-  if (name === "control") {
+  if (variant.name === "control") {
      return <button class="black">Add to cart</button>;
-  } else if (name === "test") {
+  } else if (variant.name === "test") {
      return <button class="green">Add to cart</button>;
   }
 }
+```
+
+
+## ```useExperimentAsync()```
+
+```js
+const fetchVariant = () => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve("test");
+    }, 2000);
+  });
+}
+
+function AsyncAddToCartButtonExperiment() {
+  const { variant, isLoading } = useExperimentAsync(fetchVariant);
+
+  if (isLoading) {
+    return <div>loading...</div>;
+  }
+
+  if (variant.name === "control") {
+     return <button class="black">Add to cart</button>;
+  } else if (variant.name === "test") {
+     return <button class="green">Add to cart</button>;
+  }
+}
+
 ```
 
 ### Force experiment variant

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-react-hook",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "🧪A/B-Testing React Hook",
   "author": "Julian Ustiyanovych",
   "license": "MIT",

--- a/src/__tests__/hooks/useExperimentAsync.test.js
+++ b/src/__tests__/hooks/useExperimentAsync.test.js
@@ -5,7 +5,7 @@ describe("useExperimentAsync", () => {
   const variantFetch = () =>
     new Promise(resolve => {
       setTimeout(() => {
-        resolve({ name: "test", weight: 60 });
+        resolve("test");
       }, 500);
     });
 
@@ -48,7 +48,7 @@ describe("useExperimentAsync", () => {
     await hook.waitForNextUpdate();
 
     expect(hook.result.current.isLoading).toBeFalsy();
-    expect(hook.result.current.variant).toEqual({ name: "test", weight: 60 });
+    expect(hook.result.current.variant).toEqual("test");
   });
 
   it("fetch variant with failure - reject", async () => {
@@ -61,9 +61,6 @@ describe("useExperimentAsync", () => {
     await hook.waitForNextUpdate();
 
     expect(hook.result.current.isLoading).toBeFalsy();
-    expect(hook.result.current.variant).toEqual({
-      name: "noneVariant",
-      weight: undefined
-    });
+    expect(hook.result.current.variant).toEqual("noneVariant");
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,7 +12,7 @@ export interface ExperimentResult {
 }
 
 export interface ExperimentResultAsync {
-  variant: Variant;
+  variant: string;
   isLoading?: boolean;
 }
 

--- a/src/useExperimentAsync.ts
+++ b/src/useExperimentAsync.ts
@@ -1,25 +1,25 @@
 import { useEffect, useState } from "react";
 import { NONE_VARIANT } from "./constants";
-import { ExperimentResultAsync, Variant } from "./interfaces";
+import { ExperimentResultAsync } from "./interfaces";
 
 export default function useExperimentAsyc(
   asyncFn: (...args: any[] | []) => Promise<any>,
   logger: any = console
 ): ExperimentResultAsync {
-  const [variant, setVariant] = useState<Variant>({ name: undefined, weight: undefined });
+  const [variant, setVariant] = useState<string>("");
   const [isLoading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
         try {
           setLoading(true);
-          const { name, weight } = await asyncFn();
-          setVariant({ name, weight });
+          const variant = await asyncFn();
+          setVariant(variant);
           setLoading(false);
         } catch (err) {
           logger.error(err);
           setLoading(false);
-          setVariant({ name: NONE_VARIANT, weight: undefined });
+          setVariant(NONE_VARIANT);
         }
       })();
   }, [asyncFn, logger]);


### PR DESCRIPTION
- refactoring `useExperimentAsync`.
- update README.md with `useExperimentAsync` example.